### PR TITLE
Add missing args.password_file to queue_file_downloads.py

### DIFF
--- a/queue_file_downloads.py
+++ b/queue_file_downloads.py
@@ -227,7 +227,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    password = get_password()
+    password = get_password(args.password_file)
     session_id = login(
         base_url=args.url,
         authenticator=args.authenticator,


### PR DESCRIPTION
Probably an oversight from the refactor, this needs to be passed in line with what `search_files.py` does: 
https://github.com/ral-facilities/dls-datagateway-scripts/blob/63599c424cc0e4088cc23277d0b9f65ab3def554/search_files.py#L143